### PR TITLE
mcJobs loads after the soft dependencies

### DIFF
--- a/mcJobs/src/plugin.yml
+++ b/mcJobs/src/plugin.yml
@@ -4,7 +4,7 @@ version: 3.1.9
 author: RathelmMC
 website: http://dev.bukkit.org/server-mods/mcjobs/
 dev-url: http://dev.bukkit.org/server-mods/mcjobs/
-
+softdepend: [mcMMO, WorldGuard, LogBlock, Towny]
 
 commands:
     mcjobs:


### PR DESCRIPTION
Just updated the plugin.yml to add the softdepend node, this will ensure that mcJobs loads after mcMMO, WorldGuard, LogBlock, and Towny if they are present. Should improve reliability of hooking into the events and libraries.
